### PR TITLE
fix: create and upsert should use the idField

### DIFF
--- a/src/lib/ngxs-firestore.service.ts
+++ b/src/lib/ngxs-firestore.service.ts
@@ -61,7 +61,7 @@ export abstract class NgxsFirestore<T> {
     return this.page$(queryFn).pipe(take(1));
   }
 
-  public createId() {
+  public createId(value: Partial<T>) {
     return this.firestore.createId();
   }
 
@@ -112,12 +112,12 @@ export abstract class NgxsFirestore<T> {
     let id;
     let newValue;
 
-    if (Object.keys(value).includes('id') && !!value['id']) {
-      id = value['id'];
+    if (Object.keys(value).includes(this.idField) && !!value[this.idField]) {
+      id = value[this.idField];
       newValue = Object.assign({}, value);
     } else {
-      id = this.createId();
-      newValue = Object.assign({}, value, { id });
+      id = this.createId(value);
+      newValue = Object.assign({}, value, { [this.idField]: id });
     }
 
     return this.docSet(id, newValue);
@@ -127,12 +127,12 @@ export abstract class NgxsFirestore<T> {
     let id;
     let newValue;
 
-    if (Object.keys(value).includes('id') && !!value['id']) {
-      id = value['id'];
+    if (Object.keys(value).includes(this.idField) && !!value[this.idField]) {
+      id = value[this.idField];
       newValue = Object.assign({}, value);
     } else {
-      id = this.createId();
-      newValue = Object.assign({}, value, { id });
+      id = this.createId(value);
+      newValue = Object.assign({}, value, { [this.idField]: id });
     }
 
     return this.docSet(id, newValue);

--- a/src/lib/ngxs-firestore.service.ts
+++ b/src/lib/ngxs-firestore.service.ts
@@ -61,7 +61,7 @@ export abstract class NgxsFirestore<T> {
     return this.page$(queryFn).pipe(take(1));
   }
 
-  public createId(value: Partial<T>) {
+  public createId() {
     return this.firestore.createId();
   }
 
@@ -109,18 +109,7 @@ export abstract class NgxsFirestore<T> {
   }
 
   public create$(value: Partial<T>): Observable<string> {
-    let id;
-    let newValue;
-
-    if (Object.keys(value).includes(this.idField) && !!value[this.idField]) {
-      id = value[this.idField];
-      newValue = Object.assign({}, value);
-    } else {
-      id = this.createId(value);
-      newValue = Object.assign({}, value, { [this.idField]: id });
-    }
-
-    return this.docSet(id, newValue);
+    return this.upsert$(value);
   }
 
   public upsert$(value: Partial<T>): Observable<string> {
@@ -131,7 +120,7 @@ export abstract class NgxsFirestore<T> {
       id = value[this.idField];
       newValue = Object.assign({}, value);
     } else {
-      id = this.createId(value);
+      id = this.createId();
       newValue = Object.assign({}, value, { [this.idField]: id });
     }
 


### PR DESCRIPTION
Also added the `value` to the `createId` function so that it is possible to override and generate the id from the data as opposed to relying on the `firestore.createId()`.