### PR TITLE
README update to exactly specify angularfire version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We've introduced a breaking change in order to support firebase v9. You can find
 
 | Angular | Firebase | AngularFire | @ngxs-labs/firestore-plugin |
 | ------- | -------- | ----------- | --------------------------- |
-| 12      | 9        | 7           | 1.x                         |
+| 12      | 9        | [^7.0](https://github.com/angular/angularfire#angular-and-firebase-versions)           | 1.x                         |
 | 11      | 8        | 6           | 0.x                         |
 
 ## Demo


### PR DESCRIPTION
This will save someone hours of headaches wondering why they're getting an error saying "Expected first argument to collection() to be a CollectionReference, a DocumentReference or FirebaseFirestore"

(note, the collection() reference is especially confusing when you're using doc() ..but that's an AngularFire bug)

https://stackoverflow.com/questions/73508522/expected-first-argument-to-collection-to-be-a-collectionreference-a-documentr/73643724#73643724