### PR TITLE
State improvements: avoidance of duplicate conns, avoid data creep and garbage cleanup of old conns

### DIFF
--- a/src/lib/ngxs-firestore-connect.service.ts
+++ b/src/lib/ngxs-firestore-connect.service.ts
@@ -17,14 +17,6 @@ function defaultTrackBy(action: any) {
   return '';
 }
 
-function streamId(opts: { actionType: ActionType; action: any; trackBy: (action: any) => string }) {
-  let id = `${opts.actionType.type}`;
-  if (opts.trackBy(opts.action)) {
-    id = id.concat(` (${opts.trackBy(opts.action)})`);
-  }
-  return id;
-}
-
 function tapOnce<T>(fn: (value) => void) {
   return (source: Observable<any>) =>
     defer(() => {
@@ -84,6 +76,17 @@ export class NgxsFirestoreConnect implements OnDestroy {
       }
 
       return subjects[id];
+    }
+
+    function streamId(opts: { actionType: ActionType; action: any; trackBy: (action: any) => string }) {
+      let id = `${opts.actionType.type}`;
+      if (opts.trackBy(opts.action)) {
+        id = id.concat(` (${opts.trackBy(opts.action)})`);
+      }
+      if (cancelPrevious) {
+        id = id.concat(` [cancelPrevious]`);
+      }
+      return id;
     }
 
     attachAction(NgxsFirestoreState, actionType, (_stateContext, action) => {

--- a/src/lib/ngxs-firestore.state.ts
+++ b/src/lib/ngxs-firestore.state.ts
@@ -6,13 +6,12 @@ import { Injectable } from '@angular/core';
 export interface FirestoreConnection {
   id: string;
   connectedAt: Date;
-  emmitedAt: Date[];
+  emmitedAt: Date;
 }
 
 export interface NgxsFirestoreStateModel {
   connections: FirestoreConnection[];
 }
-
 @State<NgxsFirestoreStateModel>({
   name: 'ngxs_firestore',
   defaults: {
@@ -21,18 +20,55 @@ export interface NgxsFirestoreStateModel {
 })
 @Injectable()
 export class NgxsFirestoreState implements NgxsOnInit {
-  ngxsOnInit(_ctx: StateContext<NgxsFirestoreStateModel>) {}
+  ngxsOnInit(_ctx: StateContext<NgxsFirestoreStateModel>) {
+  }
 
   @Action([NgxsFirestoreConnectActions.StreamConnected])
   streamConnected(
-    { setState }: StateContext<NgxsFirestoreStateModel>,
+    { setState, getState }: StateContext<NgxsFirestoreStateModel>,
     { payload }: NgxsFirestoreConnectActions.StreamConnected
   ) {
-    const conn = {
-      connectedAt: new Date(),
-      id: payload
-    } as FirestoreConnection;
-    setState(patch({ connections: insertItem(conn) }));
+    const state = getState();
+    const exists = state.connections.findIndex((r) => r.id === payload);
+    if (exists > -1) {
+      setState(
+        patch<NgxsFirestoreStateModel>({
+          connections: updateItem((x) => x.id === payload, patch({ connectedAt: new Date() }))
+        })
+      );
+    } else {
+      const conn = {
+        connectedAt: new Date(),
+        id: payload
+      } as FirestoreConnection;
+      setState(patch({ connections: insertItem(conn) }));
+    }
+
+    if (state.connections.length > 30) {
+      console.log('firestore-plugin cleaning connections: ' + state.connections.length);
+
+      let conns = [...state.connections];
+      conns = conns.sort((a, b) => {
+        if (a.id === b.id) {
+          return a.connectedAt < b.connectedAt ? -1 : 1;
+        } else {
+          return a.id < b.id ? -1 : 1;
+        }
+      });
+
+      conns = conns.filter((value, index, self) => {
+        if (index == self.length - 1) {
+          // keep the last value, it has to be correct
+          return true;
+        }
+        // Check ahead and remove duplicate entries older than 1 day
+        if (value.id === self[index + 1].id && value.connectedAt < self[index + 1].connectedAt) {
+          return false;
+        }
+        return true;
+      });
+      setState(patch({ connections: conns }));
+    }
   }
 
   @Action([NgxsFirestoreConnectActions.StreamEmitted])
@@ -43,7 +79,7 @@ export class NgxsFirestoreState implements NgxsOnInit {
     const { id } = payload;
     setState(
       patch<NgxsFirestoreStateModel>({
-        connections: updateItem((x) => x.id === id, patch({ emmitedAt: insertItem(new Date()) }))
+        connections: updateItem((x) => x.id === id, patch({ emmitedAt: new Date() }))
       })
     );
   }


### PR DESCRIPTION
The key issue is that firebase connections in an app, ie ionic, will often be suspended and then reaped by firestore and/or realtime and this doesn't trigger the firestore-plugin disconnect process to trim the state's connection array. We had hundreds of conns with thousands of emitted events in our test app, I don't want to think what was happening in user's apps.

What does this PR do?

- Effectively upserts new connections rather than blindly adding them
- Changes the emitted event array to a singular value, otherwise it just keeps growing
- Performs garbage cleanup of duplicates if somehow the connections array has gone over 30 items, this is a safety catch and will clean up apps with the prior firestore-plugin version