### PR TITLE
fix: spelling error on ngxsFirestoreConnections

### DIFF
--- a/integration/app/app.component.ts
+++ b/integration/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Store } from '@ngxs/store';
-import { ngxsFirectoreConnections } from '@ngxs-labs/firestore-plugin';
+import { ngxsFirestoreConnections } from '@ngxs-labs/firestore-plugin';
 
 @Component({
   selector: 'app-root',
@@ -8,7 +8,7 @@ import { ngxsFirectoreConnections } from '@ngxs-labs/firestore-plugin';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  public ngxsFirestoreState$ = this.store.select(ngxsFirectoreConnections);
+  public ngxsFirestoreState$ = this.store.select(ngxsFirestoreConnections);
 
   constructor(private store: Store) {}
 }

--- a/src/lib/ngxs-firestore-connections.selector.ts
+++ b/src/lib/ngxs-firestore-connections.selector.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@ngxs/store';
 import { NgxsFirestoreState, NgxsFirestoreStateModel } from './ngxs-firestore.state';
 
-export const ngxsFirectoreConnections = createSelector([NgxsFirestoreState], (state: NgxsFirestoreStateModel) => {
+export const ngxsFirestoreConnections = createSelector([NgxsFirestoreState], (state: NgxsFirestoreStateModel) => {
   return state.connections;
 });

--- a/src/lib/ngxs-firestore.state.spec.ts
+++ b/src/lib/ngxs-firestore.state.spec.ts
@@ -3,7 +3,7 @@ import { NgxsModule, Store } from '@ngxs/store';
 import { NgxsFirestoreModule } from './ngxs-firestore.module';
 import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
 import { getFirestore, provideFirestore } from '@angular/fire/firestore';
-import { ngxsFirectoreConnections } from './ngxs-firestore-connections.selector';
+import { ngxsFirestoreConnections } from './ngxs-firestore-connections.selector';
 
 describe('NGXS Firestore State', () => {
   let store: Store;
@@ -22,6 +22,6 @@ describe('NGXS Firestore State', () => {
   });
 
   test('State exists', () => {
-    expect(store.selectSnapshot(ngxsFirectoreConnections)).toBeTruthy();
+    expect(store.selectSnapshot(ngxsFirestoreConnections)).toBeTruthy();
   });
 });


### PR DESCRIPTION
the commit ba009a770906aa52a4e4d93f29746ced14999adc solved issue #77 